### PR TITLE
Remove usage of Laravel code and fix namespaces/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The future is now - so stop the hassle, you’re running behind. Quick and easy site deployment with Ploi. Awesome features for awesome developers. Check it out at https://ploi.io
 
-This SDK is ment for PHP applications to be able to communicate with our API.
+This SDK is meant for PHP applications to be able to communicate with our API.
 You can find our documentation at https://developers.ploi.io
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0.1"
+        "php": ">=7.2",
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^6.0|^7.0.1",
+        "illuminate/support": "^8.20"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.0|^7.0.1",
-        "illuminate/support": "^8.20"
+        "guzzlehttp/guzzle": "^6.0|^7.0.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",

--- a/src/Ploi/Http/Response.php
+++ b/src/Ploi/Http/Response.php
@@ -98,7 +98,7 @@ class Response
      */
     public function getData()
     {
-        return object_get($this->getJson(), 'data');
+        return $this->getJson()->data ?? null;
     }
 
     /**

--- a/src/Ploi/Resources/App.php
+++ b/src/Ploi/Resources/App.php
@@ -4,7 +4,7 @@ namespace Ploi\Resources;
 
 use stdClass;
 use Illuminate\Support\Arr;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class App extends Resource
 {

--- a/src/Ploi/Resources/App.php
+++ b/src/Ploi/Resources/App.php
@@ -3,7 +3,6 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use Illuminate\Support\Arr;
 use Ploi\Exceptions\Http\NotValid;
 
 class App extends Resource
@@ -52,7 +51,7 @@ class App extends Resource
         // Set the options
         $options = [
             'body' => json_encode([
-                'create_database' => Arr::get($options, 'create_database', false)
+                'create_database' => $options['create_database'] ?? false
             ]),
         ];
 

--- a/src/Ploi/Resources/Certificate.php
+++ b/src/Ploi/Resources/Certificate.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class Certificate extends Resource
 {

--- a/src/Ploi/Resources/Cronjob.php
+++ b/src/Ploi/Resources/Cronjob.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class Cronjob extends Resource
 {

--- a/src/Ploi/Resources/Daemon.php
+++ b/src/Ploi/Resources/Daemon.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class Daemon extends Resource
 {

--- a/src/Ploi/Resources/Database.php
+++ b/src/Ploi/Resources/Database.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class Database extends Resource
 {

--- a/src/Ploi/Resources/NetworkRule.php
+++ b/src/Ploi/Resources/NetworkRule.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class NetworkRule extends Resource
 {

--- a/src/Ploi/Resources/Queue.php
+++ b/src/Ploi/Resources/Queue.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class Queue extends Resource
 {

--- a/src/Ploi/Resources/Redirect.php
+++ b/src/Ploi/Resources/Redirect.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class Redirect extends Resource
 {

--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -4,6 +4,7 @@ namespace Ploi\Resources;
 
 use stdClass;
 use Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Resource\RequiresId;
 use Ploi\Exceptions\Resource\Server\Site\DomainAlreadyExists;
 
 /**

--- a/src/Ploi/Resources/SystemUser.php
+++ b/src/Ploi/Resources/SystemUser.php
@@ -3,7 +3,7 @@
 namespace Ploi\Resources;
 
 use stdClass;
-use App\Services\Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotValid;
 
 class SystemUser extends Resource
 {

--- a/tests/Ploi/Resources/ServerTest.php
+++ b/tests/Ploi/Resources/ServerTest.php
@@ -4,7 +4,7 @@ namespace Tests\Ploi\Resources;
 
 use Tests\BaseTest;
 use Ploi\Http\Response;
-use Ploi\Resources\Server\Server;
+use Ploi\Resources\Server;
 use Ploi\Exceptions\Resource\RequiresId;
 
 /**

--- a/tests/Ploi/Resources/SiteTest.php
+++ b/tests/Ploi/Resources/SiteTest.php
@@ -34,7 +34,7 @@ class SiteTest extends BaseTest
 
     public function testGetAllSites()
     {
-        $resource = $this->server->site();
+        $resource = $this->server->sites();
 
         $sites = $resource->get();
 
@@ -51,7 +51,7 @@ class SiteTest extends BaseTest
      */
     public function testGetSingleSite()
     {
-        $resource = $this->server->site();
+        $resource = $this->server->sites();
         $sites = $resource->get();
 
         if (!empty($sites->getJson()->data[0])) {
@@ -59,8 +59,8 @@ class SiteTest extends BaseTest
 
             $resource->setId($siteId);
             $methodOne = $resource->get();
-            $methodTwo = $this->server->site($siteId)->get();
-            $methodThree = $this->server->site()->get($siteId);
+            $methodTwo = $this->server->sites($siteId)->get();
+            $methodThree = $this->server->sites()->get($siteId);
 
             $this->assertInstanceOf(stdClass::class, $methodOne->getJson()->data);
             $this->assertEquals($siteId, $methodOne->getJson()->data->id);
@@ -72,7 +72,7 @@ class SiteTest extends BaseTest
     public function testCreateExampleDotCom()
     {
         try {
-            $response = $this->server->site()->create('example.com');
+            $response = $this->server->sites()->create('example.com');
 
             $this->assertInstanceOf(stdClass::class, $response);
             $this->assertNotEmpty($response->id);
@@ -81,7 +81,7 @@ class SiteTest extends BaseTest
         } catch (\Exception $e) {
             $this->assertInstanceOf(DomainAlreadyExists::class, $e);
 
-            $allSites = $this->server->site()->get();
+            $allSites = $this->server->sites()->get();
             $foundSite = false;
             foreach ($allSites->getJson()->data as $site) {
                 if ($foundSite) {
@@ -89,7 +89,7 @@ class SiteTest extends BaseTest
                 }
 
                 if ($site->domain === 'example.com') {
-                    $this->server->site($site->id)->delete();
+                    $this->server->sites($site->id)->delete();
 
                     $this->testCreateExampleDotCom();
                 }
@@ -103,11 +103,11 @@ class SiteTest extends BaseTest
     public function testCreateDuplicateSite($site)
     {
         try {
-            $this->server->site()->create('example.com');
+            $this->server->sites()->create('example.com');
         } catch (\Exception $e) {
             $this->assertInstanceOf(DomainAlreadyExists::class, $e);
 
-            $allSites = $this->server->site()->get();
+            $allSites = $this->server->sites()->get();
             $foundSite = false;
             foreach ($allSites->getJson()->data as $site) {
                 if ($foundSite) {
@@ -129,18 +129,18 @@ class SiteTest extends BaseTest
     public function testDeleteSite($site)
     {
         if (!empty($site)) {
-            $deleted = $this->server->site($site->id)->delete();
+            $deleted = $this->server->sites($site->id)->delete();
             $this->assertTrue($deleted);
         }
     }
 
     public function testDeleteInvalidSite()
     {
-        $deleted = $this->server->site(0)->delete();
+        $deleted = $this->server->sites(0)->delete();
         $this->assertFalse($deleted);
 
         try {
-            $this->server->site()->delete(1);
+            $this->server->sites()->delete(1);
         } catch (\Exception $e) {
             $this->assertInstanceOf(NotFound::class, $e);
         }
@@ -148,7 +148,7 @@ class SiteTest extends BaseTest
 
     public function testLogs()
     {
-        $resource = $this->server->site();
+        $resource = $this->server->sites();
         $sites = $resource->get();
 
         if (!empty($sites->getJson()->data[0])) {

--- a/tests/Ploi/Resources/SiteTest.php
+++ b/tests/Ploi/Resources/SiteTest.php
@@ -5,7 +5,7 @@ namespace Tests\Ploi\Resources;
 use stdClass;
 use Tests\BaseTest;
 use Ploi\Http\Response;
-use Ploi\Resources\Server\Server;
+use Ploi\Resources\Server;
 use Ploi\Exceptions\Http\NotFound;
 use Ploi\Exceptions\Resource\Server\Site\DomainAlreadyExists;
 


### PR DESCRIPTION
Changed to PHP =>7.2 after speaking with Dennis.

Noticed there were some invalid namespaces in some cases (`App\Services` not existing and `Illuminate\Support` not being required by composer.json).

Also fixed a typo in the README.