### PR TITLE
Add endpoints for opcache, test domains, php versions, service restarts and scripts

### DIFF
--- a/src/Ploi/Exceptions/Http/NotAllowed.php
+++ b/src/Ploi/Exceptions/Http/NotAllowed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ploi\Exceptions\Http;
+
+use Exception;
+
+/**
+ * Class NotAllowed
+ *
+ * @package Ploi\Exceptions\Http
+ */
+class NotAllowed extends Exception
+{
+
+    /**
+     * NotAllowed constructor.
+     *
+     * @param string $message
+     */
+    public function __construct(string $message = "Method not allowed")
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Ploi/Exceptions/Resource/Script/InvalidUser.php
+++ b/src/Ploi/Exceptions/Resource/Script/InvalidUser.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Ploi\Exceptions\Resource\Script;
+
+use Exception;
+
+class InvalidUser extends Exception
+{
+    /**
+     * InvalidUser constructor.
+     *
+     * @param string $message
+     */
+    public function __construct(string $message = "User is not valid")
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Ploi/Exceptions/Resource/Server/Service/InvalidServiceName.php
+++ b/src/Ploi/Exceptions/Resource/Server/Service/InvalidServiceName.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Ploi\Exceptions\Resource\Server\Service;
+
+use Exception;
+
+class InvalidServiceName extends Exception
+{
+    /**
+     * InvalidServiceName constructor.
+     *
+     * @param string $message
+     */
+    public function __construct(string $message = "Service name is not valid")
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Ploi/Exceptions/Resource/Server/Service/RequiresServiceName.php
+++ b/src/Ploi/Exceptions/Resource/Server/Service/RequiresServiceName.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Ploi\Exceptions\Resource\Server\Service;
+
+use Exception;
+
+class RequiresServiceName extends Exception
+{
+    /**
+     * RequiresServiceName constructor.
+     *
+     * @param string $message
+     */
+    public function __construct(string $message = "Service name is required")
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Ploi/Ploi.php
+++ b/src/Ploi/Ploi.php
@@ -9,6 +9,7 @@ use Ploi\Resources\User;
 use Ploi\Resources\Server;
 use Ploi\Exceptions\Http\NotFound;
 use Ploi\Exceptions\Http\NotValid;
+use Ploi\Exceptions\Http\NotAllowed;
 use Psr\Http\Message\ResponseInterface;
 use Ploi\Exceptions\Http\TooManyAttempts;
 use Ploi\Exceptions\Http\Unauthenticated;
@@ -94,6 +95,7 @@ class Ploi
      * @param array<string, mixed> $options
      * @return Response
      * @throws NotFound
+     * @throws NotAllowed
      * @throws TooManyAttempts
      * @throws PerformingMaintenance
      * @throws InternalServerError
@@ -120,6 +122,8 @@ class Ploi
                 throw new Unauthenticated($response->getBody());
             case 404:
                 throw new NotFound($response->getBody());
+            case 405:
+                throw new NotAllowed($response->getBody());
             case 422:
                 throw new NotValid($response->getBody());
             case 429:

--- a/src/Ploi/Ploi.php
+++ b/src/Ploi/Ploi.php
@@ -5,6 +5,7 @@ namespace Ploi;
 use Exception;
 use GuzzleHttp\Client;
 use Ploi\Http\Response;
+use Ploi\Resources\Script;
 use Ploi\Resources\User;
 use Ploi\Resources\Server;
 use Ploi\Exceptions\Http\NotFound;
@@ -146,6 +147,11 @@ class Ploi
     public function server(int $id = null)
     {
         return new Server($this, $id);
+    }
+
+    public function scripts(int $id = null): Script
+    {
+        return new Script($this, $id);
     }
 
     public function user()

--- a/src/Ploi/Resources/Script.php
+++ b/src/Ploi/Resources/Script.php
@@ -67,7 +67,7 @@ class Script extends Resource
         return $response->getJson();
     }
 
-    public function delete(int $id): bool
+    public function delete(int $id = null): bool
     {
         if ($id) {
             $this->setId($id);
@@ -83,7 +83,7 @@ class Script extends Resource
         return $response->getResponse()->getStatusCode() === 200;
     }
 
-    public function run(int $id, array $serverIds): stdClass
+    public function run(int $id = null, array $serverIds = []): stdClass
     {
         if ($id) {
             $this->setId($id);

--- a/src/Ploi/Resources/Script.php
+++ b/src/Ploi/Resources/Script.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Ploi\Resources;
+
+use Ploi\Exceptions\Resource\Script\InvalidUser;
+use stdClass;
+use Ploi\Ploi;
+use Ploi\Exceptions\Resource\RequiresId;
+
+class Script extends Resource
+{
+    private $endpoint = 'scripts';
+
+    private $availableUsers = [
+        'ploi',
+        'root',
+    ];
+
+    public function __construct(Ploi $ploi = null, int $id = null)
+    {
+        parent::__construct($ploi, $id);
+
+        $this->setEndpoint($this->endpoint);
+    }
+
+    public function get(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if ($this->getId()) {
+            $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
+        }
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint());
+
+        return $response->getJson();
+    }
+
+    public function create(
+        string $label,
+        string $user,
+        string $content
+    ): stdClass
+    {
+        $this->setId(null);
+
+        if (!in_array($user, $this->availableUsers)) {
+            throw new InvalidUser(
+                'User not valid, available users: ' . implode(', ', $this->availableUsers)
+            );
+        }
+
+        $options = [
+            'body' => json_encode([
+                'label' => $label,
+                'user' => $user,
+                'content' => $content,
+            ]),
+        ];
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint(), 'post', $options);
+
+        $this->setId($response->getJson()->data->id);
+
+        return $response->getJson();
+    }
+
+    public function delete(int $id): bool
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+        if (!$this->getId()) {
+            throw new RequiresId('Script ID is required');
+        }
+
+        $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint(), 'delete');
+
+        return $response->getResponse()->getStatusCode() === 200;
+    }
+
+    public function run(int $id, array $serverIds): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+        if (!$this->getId()) {
+            throw new RequiresId('Script ID is required');
+        }
+        if (!count($serverIds)) {
+            throw new RequiresId('Server IDs are required');
+        }
+        $options = [
+            'body' => json_encode([
+                'servers' => $serverIds
+            ])
+        ];
+
+        $this->setEndpoint($this->getEndpoint() . '/' . $this->getId() . '/run');
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint(), 'post', $options);
+
+        return $response->getJson();
+    }
+}

--- a/src/Ploi/Resources/Server.php
+++ b/src/Ploi/Resources/Server.php
@@ -174,6 +174,11 @@ class Server extends Resource
         return new Site($this, $id);
     }
 
+    public function services(string $serviceName = null): Service
+    {
+        return new Service($this, $serviceName);
+    }
+
     public function databases($id = null): Database
     {
         return new Database($this, $id);

--- a/src/Ploi/Resources/Server.php
+++ b/src/Ploi/Resources/Server.php
@@ -152,6 +152,23 @@ class Server extends Resource
         return $response->getJson();
     }
 
+    public function phpVersions(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No server ID set');
+        }
+
+        $this->setEndpoint($this->endpoint . '/' . $this->getId());
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/php/versions', 'get');
+
+        return $response->getJson();
+    }
+
     public function sites($id = null): Site
     {
         return new Site($this, $id);

--- a/src/Ploi/Resources/Server.php
+++ b/src/Ploi/Resources/Server.php
@@ -101,6 +101,57 @@ class Server extends Resource
         return $response->getData();
     }
 
+    public function refreshOpcache(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No server ID set');
+        }
+
+        $this->setEndpoint($this->endpoint . '/' . $this->getId());
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/refresh-opcache', 'post');
+
+        return $response->getJson();
+    }
+
+    public function enableOpcache(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No server ID set');
+        }
+
+        $this->setEndpoint($this->endpoint . '/' . $this->getId());
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/enable-opcache', 'post');
+
+        return $response->getJson();
+    }
+
+    public function disableOpcache(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No server ID set');
+        }
+
+        $this->setEndpoint($this->endpoint . '/' . $this->getId());
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/disable-opcache', 'delete');
+
+        return $response->getJson();
+    }
+
     public function sites($id = null): Site
     {
         return new Site($this, $id);

--- a/src/Ploi/Resources/Service.php
+++ b/src/Ploi/Resources/Service.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace Ploi\Resources;
+
+use stdClass;
+use Ploi\Exceptions\Resource\Server\Service\InvalidServiceName;
+use Ploi\Exceptions\Resource\Server\Service\RequiresServiceName;
+
+class Service extends Resource
+{
+    private $server;
+    private $serviceName;
+    private $availableServices = [
+        'mysql',
+        'nginx',
+        'supervisor',
+    ];
+
+    public function __construct(Server $server, string $serviceName = null)
+    {
+        parent::__construct($server->getPloi());
+
+        $this->setServer($server);
+
+        if ($serviceName) {
+            $this->setServiceName($serviceName);
+        }
+
+        $this->buildEndpoint();
+    }
+
+    public function buildEndpoint(): self
+    {
+        $this->setEndpoint($this->getServer()->getEndpoint() . '/' . $this->getServer()->getId() . '/services');
+
+        if ($this->getServiceName()) {
+            $this->setEndpoint($this->getEndpoint() . '/' . $this->getServiceName());
+        }
+
+        return $this;
+    }
+
+    public function getServiceName(): ?string
+    {
+        return $this->serviceName;
+    }
+
+    public function setServiceName(string $serviceName): self
+    {
+        if (!in_array($serviceName, $this->availableServices)) {
+            throw new InvalidServiceName;
+        }
+
+        $this->serviceName = $serviceName;
+
+        $this->addHistory('Resource service name set to ' . $serviceName);
+
+        return $this;
+    }
+
+    public function restart(string $serviceName = null): stdClass
+    {
+
+        if ($serviceName) {
+            $this->setServiceName($serviceName);
+        }
+
+        if (!$this->getServiceName()) {
+            throw new RequiresServiceName;
+        }
+
+        $this->buildEndpoint();
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/restart', 'post');
+
+        return $response->getJson();
+    }
+
+}

--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -168,6 +168,23 @@ class Site extends Resource
         return $response->getJson();
     }
 
+    public function testDomain(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No Site ID set');
+        }
+
+        $this->buildEndpoint();
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/test-domain', 'get');
+
+        return $response->getJson();
+    }
+
     public function enableTestDomain(int $id = null): stdClass
     {
         if ($id) {

--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -168,6 +168,40 @@ class Site extends Resource
         return $response->getJson();
     }
 
+    public function enableTestDomain(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No Site ID set');
+        }
+
+        $this->buildEndpoint();
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/test-domain', 'post');
+
+        return $response->getJson();
+    }
+
+    public function disableTestDomain(int $id = null): stdClass
+    {
+        if ($id) {
+            $this->setId($id);
+        }
+
+        if (!$this->getId()) {
+            throw new RequiresId('No Site ID set');
+        }
+
+        $this->buildEndpoint();
+
+        $response = $this->getPloi()->makeAPICall($this->getEndpoint() . '/test-domain', 'delete');
+
+        return $response->getJson();
+    }
+
     public function redirects($id = null): Redirect
     {
         return new Redirect($this->getServer(), $this, $id);


### PR DESCRIPTION
Added:
- opcache: enable, disable, refresh
- test domain: enable, disable
- php versions: list
- services: restart
- scripts: list, get, create, delete, run

Also added a HTTP 405 Method Not Allowed exception.