### PR TITLE
Return data instead of json

### DIFF
--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -100,11 +100,13 @@ class Site extends Resource
             throw $exception;
         }
 
+        $data = $response->getData();
+
         // Set the id of the site
-        $this->setId($response->getJson()->data->id);
+        $this->setId($data->id);
 
         // Return the data
-        return $response->getJson();
+        return $data;
     }
 
     public function delete(int $id = null): bool


### PR DESCRIPTION
This follows the convention from other similar endpoints and makes more sense to me to return the actual data/site object rather than the decoded json.