### PR TITLE
Add rule_type parameter to NetworkRule create()

### DIFF
--- a/src/Ploi/Resources/NetworkRule.php
+++ b/src/Ploi/Resources/NetworkRule.php
@@ -40,7 +40,7 @@ class NetworkRule extends Resource
         return $this->getPloi()->makeAPICall($this->getEndpoint());
     }
 
-    public function create(string $name, int $port, string $type = 'tcp', string $fromIpAddress): Response
+    public function create(string $name, int $port, string $type = 'tcp', string $ruleType = 'allow', string $fromIpAddress): Response
     {
         // Remove the id
         $this->setId(null);
@@ -51,6 +51,7 @@ class NetworkRule extends Resource
                 'name' => $name,
                 'port' => $port,
                 'type' => $type,
+                'rule_type' => $ruleType,
                 'from_ip_address' => $fromIpAddress,
             ]),
         ];

--- a/src/Ploi/Resources/NetworkRule.php
+++ b/src/Ploi/Resources/NetworkRule.php
@@ -40,7 +40,7 @@ class NetworkRule extends Resource
         return $this->getPloi()->makeAPICall($this->getEndpoint());
     }
 
-    public function create(string $name, int $port, string $type = 'tcp', string $ruleType = 'allow', string $fromIpAddress): Response
+    public function create(string $name, int $port, string $type = 'tcp', string $fromIpAddress, string $ruleType = 'allow'): Response
     {
         // Remove the id
         $this->setId(null);


### PR DESCRIPTION
Following the documentation from https://developers.ploi.io/network-rules/create-network-rule.

``rule_type`` is listed as a required parameter, however it works without sending it.

**Should this parameter be changed to optional on documentation?**