### PR TITLE
Fallback to just json and not null

### DIFF
--- a/src/Ploi/Http/Response.php
+++ b/src/Ploi/Http/Response.php
@@ -98,7 +98,7 @@ class Response
      */
     public function getData()
     {
-        return $this->getJson()->data ?? null;
+        return $this->getJson()->data ?? $this->getJson();
     }
 
     /**


### PR DESCRIPTION
Some responses have a `data` property, but it seems a little inconsistent. Perhaps falling back to `getJson` when there isn't a `data` property is reasonable?