### PR TITLE
Fix get() method not respecting perPage() definitions

### DIFF
--- a/src/Ploi/Resources/AuthUser.php
+++ b/src/Ploi/Resources/AuthUser.php
@@ -44,7 +44,7 @@ class AuthUser extends Resource
 
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/AuthUser.php
+++ b/src/Ploi/Resources/AuthUser.php
@@ -44,7 +44,7 @@ class AuthUser extends Resource
 
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/AuthUser.php
+++ b/src/Ploi/Resources/AuthUser.php
@@ -44,7 +44,9 @@ class AuthUser extends Resource
 
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $name, string $password): Response

--- a/src/Ploi/Resources/Certificate.php
+++ b/src/Ploi/Resources/Certificate.php
@@ -42,7 +42,9 @@ class Certificate extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $certificate, string $type = 'letsencrypt'): Response

--- a/src/Ploi/Resources/Certificate.php
+++ b/src/Ploi/Resources/Certificate.php
@@ -42,7 +42,7 @@ class Certificate extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Certificate.php
+++ b/src/Ploi/Resources/Certificate.php
@@ -42,7 +42,7 @@ class Certificate extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Cronjob.php
+++ b/src/Ploi/Resources/Cronjob.php
@@ -40,7 +40,7 @@ class Cronjob extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Cronjob.php
+++ b/src/Ploi/Resources/Cronjob.php
@@ -40,7 +40,7 @@ class Cronjob extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Cronjob.php
+++ b/src/Ploi/Resources/Cronjob.php
@@ -40,7 +40,9 @@ class Cronjob extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $command, string $frequency, string $user = 'ploi'): Response

--- a/src/Ploi/Resources/Daemon.php
+++ b/src/Ploi/Resources/Daemon.php
@@ -40,7 +40,7 @@ class Daemon extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Daemon.php
+++ b/src/Ploi/Resources/Daemon.php
@@ -40,7 +40,9 @@ class Daemon extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $command, string $systemUser, int $processes, ?string $directory = null): Response

--- a/src/Ploi/Resources/Daemon.php
+++ b/src/Ploi/Resources/Daemon.php
@@ -40,7 +40,7 @@ class Daemon extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Database.php
+++ b/src/Ploi/Resources/Database.php
@@ -44,7 +44,9 @@ class Database extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $name, string $user, string $password, $description = null, $siteId = null): Response

--- a/src/Ploi/Resources/Database.php
+++ b/src/Ploi/Resources/Database.php
@@ -44,7 +44,7 @@ class Database extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Database.php
+++ b/src/Ploi/Resources/Database.php
@@ -44,7 +44,7 @@ class Database extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/DatabaseBackup.php
+++ b/src/Ploi/Resources/DatabaseBackup.php
@@ -48,7 +48,7 @@ class DatabaseBackup extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/DatabaseBackup.php
+++ b/src/Ploi/Resources/DatabaseBackup.php
@@ -48,7 +48,7 @@ class DatabaseBackup extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/DatabaseBackup.php
+++ b/src/Ploi/Resources/DatabaseBackup.php
@@ -48,7 +48,9 @@ class DatabaseBackup extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(

--- a/src/Ploi/Resources/DatabaseUser.php
+++ b/src/Ploi/Resources/DatabaseUser.php
@@ -40,7 +40,7 @@ class DatabaseUser extends Resource
 
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/DatabaseUser.php
+++ b/src/Ploi/Resources/DatabaseUser.php
@@ -40,7 +40,7 @@ class DatabaseUser extends Resource
 
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/DatabaseUser.php
+++ b/src/Ploi/Resources/DatabaseUser.php
@@ -40,7 +40,9 @@ class DatabaseUser extends Resource
 
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $user, string $password): Response

--- a/src/Ploi/Resources/Incident.php
+++ b/src/Ploi/Resources/Incident.php
@@ -53,7 +53,9 @@ class Incident extends Resource
 
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $title, string $description, string $severity): Response

--- a/src/Ploi/Resources/Incident.php
+++ b/src/Ploi/Resources/Incident.php
@@ -53,7 +53,7 @@ class Incident extends Resource
 
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Incident.php
+++ b/src/Ploi/Resources/Incident.php
@@ -53,7 +53,7 @@ class Incident extends Resource
 
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Insight.php
+++ b/src/Ploi/Resources/Insight.php
@@ -41,7 +41,7 @@ class Insight extends Resource
 
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Insight.php
+++ b/src/Ploi/Resources/Insight.php
@@ -41,7 +41,7 @@ class Insight extends Resource
 
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Insight.php
+++ b/src/Ploi/Resources/Insight.php
@@ -41,7 +41,9 @@ class Insight extends Resource
 
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function detail(?int $id = null): Response

--- a/src/Ploi/Resources/NetworkRule.php
+++ b/src/Ploi/Resources/NetworkRule.php
@@ -40,7 +40,7 @@ class NetworkRule extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/NetworkRule.php
+++ b/src/Ploi/Resources/NetworkRule.php
@@ -40,7 +40,7 @@ class NetworkRule extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/NetworkRule.php
+++ b/src/Ploi/Resources/NetworkRule.php
@@ -40,7 +40,9 @@ class NetworkRule extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $name, int $port, string $type = 'tcp', ?string $fromIpAddress = null, string $ruleType = 'allow'): Response

--- a/src/Ploi/Resources/Opcache.php
+++ b/src/Ploi/Resources/Opcache.php
@@ -3,13 +3,12 @@
 namespace Ploi\Resources;
 
 use Ploi\Http\Response;
-use Ploi\Traits\HasPagination;
 
 class Opcache extends Resource
 {
     private $server;
 
-    public function __construct(Server $server, int $id = null)
+    public function __construct(Server $server, ?int $id = null)
     {
         parent::__construct($server->getPloi(), $id);
 

--- a/src/Ploi/Resources/Queue.php
+++ b/src/Ploi/Resources/Queue.php
@@ -42,7 +42,7 @@ class Queue extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Queue.php
+++ b/src/Ploi/Resources/Queue.php
@@ -42,7 +42,7 @@ class Queue extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Queue.php
+++ b/src/Ploi/Resources/Queue.php
@@ -42,7 +42,9 @@ class Queue extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(

--- a/src/Ploi/Resources/Redirect.php
+++ b/src/Ploi/Resources/Redirect.php
@@ -42,7 +42,9 @@ class Redirect extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (!$id)
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint());
     }
 
     public function create(string $redirectFrom, string $redirectTo, $type = 'redirect'): Response

--- a/src/Ploi/Resources/Redirect.php
+++ b/src/Ploi/Resources/Redirect.php
@@ -42,7 +42,7 @@ class Redirect extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId())
+        return (is_null($this->getId()))
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint());
     }

--- a/src/Ploi/Resources/Redirect.php
+++ b/src/Ploi/Resources/Redirect.php
@@ -42,7 +42,7 @@ class Redirect extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (!$id)
+        return (! $this->getId())
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint());
     }

--- a/src/Ploi/Resources/Script.php
+++ b/src/Ploi/Resources/Script.php
@@ -30,7 +30,7 @@ class Script extends Resource
             $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
         }
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Script.php
+++ b/src/Ploi/Resources/Script.php
@@ -30,7 +30,7 @@ class Script extends Resource
             $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
         }
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Script.php
+++ b/src/Ploi/Resources/Script.php
@@ -30,7 +30,9 @@ class Script extends Resource
             $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
         }
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(

--- a/src/Ploi/Resources/Server.php
+++ b/src/Ploi/Resources/Server.php
@@ -54,7 +54,7 @@ class Server extends Resource
         // This method do not need the special callApi() method on pagination 
         // Since its a the simple get of the servers using the $this->endpoint url
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->callApi(); 
     }

--- a/src/Ploi/Resources/Server.php
+++ b/src/Ploi/Resources/Server.php
@@ -22,7 +22,7 @@ class Server extends Resource
 
     public function buildEndpoint(string $path = null): string
     {
-        $base = 'servers';
+        $base = $this->endpoint;
 
         if ($this->getId()) {
             $base = "{$base}/{$this->getId()}";
@@ -51,7 +51,12 @@ class Server extends Resource
             $this->setId($id);
         }
 
-        return $this->callApi();
+        // This method do not need the special callApi() method on pagination 
+        // Since its a the simple get of the servers using the $this->endpoint url
+
+        return (! $id) 
+            ? $this->page()
+            : $this->callApi(); 
     }
 
     public function delete(int $id = null): Response

--- a/src/Ploi/Resources/Server.php
+++ b/src/Ploi/Resources/Server.php
@@ -54,7 +54,7 @@ class Server extends Resource
         // This method do not need the special callApi() method on pagination 
         // Since its a the simple get of the servers using the $this->endpoint url
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->callApi(); 
     }

--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -36,7 +36,7 @@ class Site extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -36,7 +36,9 @@ class Site extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function getServer(): Server

--- a/src/Ploi/Resources/Site.php
+++ b/src/Ploi/Resources/Site.php
@@ -36,7 +36,7 @@ class Site extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/SshKey.php
+++ b/src/Ploi/Resources/SshKey.php
@@ -41,7 +41,7 @@ class SshKey extends Resource
 
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/SshKey.php
+++ b/src/Ploi/Resources/SshKey.php
@@ -41,7 +41,9 @@ class SshKey extends Resource
 
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $name, string $key, ?string $systemUser = null): Response

--- a/src/Ploi/Resources/SshKey.php
+++ b/src/Ploi/Resources/SshKey.php
@@ -41,7 +41,7 @@ class SshKey extends Resource
 
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/StatusPage.php
+++ b/src/Ploi/Resources/StatusPage.php
@@ -38,7 +38,9 @@ class StatusPage extends Resource
 
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function incident(?int $id = null): Incident

--- a/src/Ploi/Resources/StatusPage.php
+++ b/src/Ploi/Resources/StatusPage.php
@@ -38,7 +38,7 @@ class StatusPage extends Resource
 
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/StatusPage.php
+++ b/src/Ploi/Resources/StatusPage.php
@@ -38,7 +38,7 @@ class StatusPage extends Resource
 
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/SystemUser.php
+++ b/src/Ploi/Resources/SystemUser.php
@@ -40,7 +40,7 @@ class SystemUser extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/SystemUser.php
+++ b/src/Ploi/Resources/SystemUser.php
@@ -40,7 +40,9 @@ class SystemUser extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 
     public function create(string $name, bool $sudo = false): Response

--- a/src/Ploi/Resources/SystemUser.php
+++ b/src/Ploi/Resources/SystemUser.php
@@ -40,7 +40,7 @@ class SystemUser extends Resource
         // Make sure the endpoint is built
         $this->buildEndpoint();
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/WebserverTemplate.php
+++ b/src/Ploi/Resources/WebserverTemplate.php
@@ -29,6 +29,8 @@ class WebserverTemplate extends Resource
             $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
         }
 
-        return $this->getPloi()->makeAPICall($this->getEndpoint());
+        return (! $id) 
+            ? $this->page()
+            : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }
 }

--- a/src/Ploi/Resources/WebserverTemplate.php
+++ b/src/Ploi/Resources/WebserverTemplate.php
@@ -29,7 +29,7 @@ class WebserverTemplate extends Resource
             $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
         }
 
-        return (! $this->getId()) 
+        return (is_null($this->getId())) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }

--- a/src/Ploi/Resources/WebserverTemplate.php
+++ b/src/Ploi/Resources/WebserverTemplate.php
@@ -29,7 +29,7 @@ class WebserverTemplate extends Resource
             $this->setEndpoint($this->getEndpoint() . '/' . $this->getId());
         }
 
-        return (! $id) 
+        return (! $this->getId()) 
             ? $this->page()
             : $this->getPloi()->makeAPICall($this->getEndpoint()); 
     }


### PR DESCRIPTION
This pull request fixs the `get()` method currently not respecting the amounts per page set for methods with pagination supported.