### PR TITLE
Ignore PHPStan error in FileBackup

### DIFF
--- a/phpstan-ignore.php
+++ b/phpstan-ignore.php
@@ -1,0 +1,9 @@
+<?php
+
+$config = [];
+
+if (PHP_VERSION_ID >= 80400) {
+	$config['parameters']['ignoreErrors'] = [['identifier' => 'parameter.implicitlyNullable']];
+}
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+	- phpstan-ignore.php
 parameters:
 	level: 5
 	paths:


### PR DESCRIPTION
While we're supporting PHP <8.4